### PR TITLE
Resolved SB compilation and sass installation

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -79,20 +79,12 @@ gulp.task('serve', function () {
     shelljs.exec('node --max-old-space-size=8192 node_modules/gulp/bin/gulp serve-max', { silent: false });
 });
 
-
-
-
 /**
  * Compile styles
  */
 gulp.task('styles', function () {
-    var sass = require('gulp-sass');
-    return gulp.src(['./**/*.scss', '!./node_modules/**/*.scss'], { base: './' })
-        .pipe(sass({
-            outputStyle: 'expanded',
-            includePaths: './node_modules/@syncfusion/'
-        }))
-        .pipe(gulp.dest('.'));
+    gulp.src('./node_modules/@syncfusion/ej2/*.css')
+    .pipe(gulp.dest('./styles/'));
 });
 
 gulp.task('generate-router', function (done) {
@@ -186,7 +178,7 @@ gulp.task('build', function (done) {
 });
 
 gulp.task('react-build', function (done) {
-    runSequence('create-locale','generate-router','styles','scripts','bundle','plnkr-json','cssfile', done);
+    runSequence('create-locale','generate-router','styles','scripts','bundle','plnkr-json', done);
 });
 
 gulp.task('bundle', function () {
@@ -370,7 +362,4 @@ gulp.task('serve-max', ['react-build'], function (done) {
     };
     bs.init(options, done);
 });
-gulp.task('cssfile', function () {
-    gulp.src('./node_modules/@syncfusion/ej2/*.css')
-    .pipe(gulp.dest('./styles/'));
-});
+

--- a/package.json
+++ b/package.json
@@ -77,7 +77,8 @@
         "gulp-sass": "^3.1.0",
         "gulp-typescript": "^3.1.6",
         "run-sequence": "^2.2.0",
-        "shelljs": "^0.7.8",
+        "shelljs": "*",
+        "node-sass": "4.12.0",
         "requirejs": "^2.3.3",
         "typescript": "2.3.4"
     },


### PR DESCRIPTION
## bug

**Issue** - https://github.com/syncfusion/ej2-react-samples/issues/7

## Description:

While installing `node_modules` it throws `ode-sasss` isue due to node compatibility.

## Solution:
replaced styles compilation and used latest `node-sass` version