### PR TITLE
Fix y axis value for Bollinger Bands chart

### DIFF
--- a/src/chart/bollinger.tsx
+++ b/src/chart/bollinger.tsx
@@ -55,7 +55,7 @@ export class Bollinger extends SampleBase<{}, {}> {
                             BollingerBands]} />
                         <SeriesCollectionDirective>
                             <SeriesDirective dataSource={chartData} width={2}
-                                xName='x' yName='y' low='low' high='high' close='close' volume='volume' open='open'
+                                xName='x' yName='low' low='low' high='high' close='close' volume='volume' open='open'
                                 name='Apple Inc' bearFillColor='#2ecd71' bullFillColor='#e74c3d'
                                 type='Candle' animation={{ enable: false }}>
                             </SeriesDirective>


### PR DESCRIPTION
The `chartData` values from `'./financial-data'` do not have a `y` property. From what I understood, after reading [Financial Charts in React Chart component](https://ej2.syncfusion.com/react/documentation/chart/getting-started/), the `yName` should point to the `low` property of the chart data.